### PR TITLE
feat: v0.2.0 Supacrawl perception layer - browse, screenshot, click tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,17 +18,30 @@ User Input -> ADK Runner -> Gemini Reasoning -> Tool Call (Supacrawl) -> Visual 
 
 Monorepo layout:
 - `apps/golem/` -- the agent (own go.mod)
-  - `cmd/golem/main.go` -- entry point and wiring
-  - `internal/adk/` -- model factory, runner setup, agent config
-  - `internal/browser/` -- Supacrawl client and browser_action tool
-  - `internal/perception/` -- state mapping, hidden element detection
-  - `internal/security/` -- attack trees, payload engineering
-  - `internal/report/` -- regex-based parser for vulnerability reports
+  - `cmd/golem/main.go` -- entry point, wiring, event loop
+  - `internal/adk/` -- model factory, runner setup, agent config, ADK tool definitions
+  - `internal/supacrawl/` -- HTTP client for scraper API (scrape, screenshot, health)
+  - `internal/perception/` -- state mapping, hidden element detection (planned)
+  - `internal/security/` -- attack trees, payload engineering (planned)
+  - `internal/report/` -- regex-based parser for vulnerability reports (planned)
 - `apps/scraper/` -- Supacrawler perception layer (own go.mod)
   - Provides `/v1/scrape`, `/v1/screenshots` endpoints
   - LightPanda browser automation, Redis task queue
 
 Key constraint (ADK-Go v0.6.0): `OutputSchema` and `Tools` are mutually exclusive. Because this agent uses tools, structured output must use the Regex Parser pattern.
+
+### agent tools
+
+The agent has these tools registered via `functiontool.New`:
+
+| Tool | Purpose | Supacrawl Endpoint |
+|------|---------|--------------------|
+| `echo` | Verify tool-call loop works | none (built-in) |
+| `browse` | Scrape a URL, get markdown + links + metadata | `GET /v1/scrape` |
+| `screenshot` | Take a screenshot, return image URL | `POST + GET /v1/screenshots` |
+| `click` | Click a CSS selector, screenshot + scrape the result | screenshot + scrape |
+
+Tool registration is graceful: if `SUPACRAWL_API_URL` is not set or the scraper is unreachable, the agent starts with `echo` only and logs a warning.
 
 ## tech stack
 

--- a/apps/golem/cmd/golem/main.go
+++ b/apps/golem/cmd/golem/main.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/genai"
 
 	golemAdk "golem/internal/adk"
+	"golem/internal/supacrawl"
 )
 
 func main() {
@@ -28,13 +29,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	echoTool, err := golemAdk.NewEchoTool()
+	tools, err := buildTools()
 	if err != nil {
-		slog.Error("failed to create echo tool", "error", err)
+		slog.Error("failed to create tools", "error", err)
 		os.Exit(1)
 	}
 
-	auditor, err := golemAdk.NewAuditor(llm, []tool.Tool{echoTool})
+	auditor, err := golemAdk.NewAuditor(llm, tools)
 	if err != nil {
 		slog.Error("failed to create auditor agent", "error", err)
 		os.Exit(1)
@@ -55,7 +56,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	prompt := "Use the echo tool to say 'hello from golem'. Then confirm it worked."
+	prompt := "Browse https://example.com and describe what you see."
 	if len(os.Args) > 1 {
 		prompt = os.Args[1]
 	}
@@ -69,32 +70,63 @@ func main() {
 			break
 		}
 
-		if event.Content != nil {
-			for _, part := range event.Content.Parts {
-				if part.FunctionCall != nil {
-					slog.Info("tool call",
-						"tool", part.FunctionCall.Name,
-						"args", part.FunctionCall.Args,
-					)
-				}
-				if part.FunctionResponse != nil {
-					slog.Info("tool response",
-						"tool", part.FunctionResponse.Name,
-						"result", part.FunctionResponse.Response,
-					)
-				}
-				if part.Text != "" {
-					if event.IsFinalResponse() {
-						fmt.Println("\n--- AGENT RESPONSE ---")
-						fmt.Println(part.Text)
-						fmt.Println("--- END ---")
-					} else {
-						slog.Info("agent thinking", "text", part.Text)
-					}
+		if event.Content == nil {
+			continue
+		}
+
+		for _, part := range event.Content.Parts {
+			if part.FunctionCall != nil {
+				slog.Info("tool call",
+					"tool", part.FunctionCall.Name,
+					"args", part.FunctionCall.Args,
+				)
+			}
+			if part.FunctionResponse != nil {
+				slog.Info("tool response",
+					"tool", part.FunctionResponse.Name,
+				)
+			}
+			if part.Text != "" {
+				if event.IsFinalResponse() {
+					fmt.Println("\n--- AGENT RESPONSE ---")
+					fmt.Println(part.Text)
+					fmt.Println("--- END ---")
+				} else {
+					slog.Info("agent thinking", "text", part.Text)
 				}
 			}
 		}
 	}
 
 	slog.Info("agent run complete")
+}
+
+func buildTools() ([]tool.Tool, error) {
+	echoTool, err := golemAdk.NewEchoTool()
+	if err != nil {
+		return nil, fmt.Errorf("create echo tool: %w", err)
+	}
+
+	tools := []tool.Tool{echoTool}
+
+	client, err := supacrawl.NewClient()
+	if err != nil {
+		slog.Warn("supacrawl not configured, running with echo tool only", "error", err)
+		return tools, nil
+	}
+
+	if err := client.Health(context.Background()); err != nil {
+		slog.Warn("supacrawl not reachable, running with echo tool only", "error", err)
+		return tools, nil
+	}
+
+	slog.Info("supacrawl connected", "url", os.Getenv("SUPACRAWL_API_URL"))
+
+	supacrawlTools, err := golemAdk.NewSupacrawlTools(client)
+	if err != nil {
+		return nil, fmt.Errorf("create supacrawl tools: %w", err)
+	}
+
+	tools = append(tools, supacrawlTools...)
+	return tools, nil
 }

--- a/apps/golem/internal/adk/runner.go
+++ b/apps/golem/internal/adk/runner.go
@@ -1,6 +1,8 @@
 package adk
 
 import (
+	"fmt"
+
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/runner"
 	"google.golang.org/adk/session"
@@ -15,7 +17,7 @@ func NewRunner(appName string, rootAgent agent.Agent) (*runner.Runner, session.S
 		SessionService: sessionSvc,
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("create runner: %w", err)
 	}
 
 	return r, sessionSvc, nil

--- a/apps/golem/internal/adk/tools.go
+++ b/apps/golem/internal/adk/tools.go
@@ -2,6 +2,9 @@ package adk
 
 import (
 	"fmt"
+	"strings"
+
+	"golem/internal/supacrawl"
 
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
@@ -27,4 +30,220 @@ func NewEchoTool() (tool.Tool, error) {
 		},
 		echo,
 	)
+}
+
+type browseArgs struct {
+	URL         string `json:"url" jsonschema:"The URL to browse and scrape content from"`
+	IncludeHTML bool   `json:"include_html,omitempty" jsonschema:"Whether to include raw HTML in the response"`
+	Fresh       bool   `json:"fresh,omitempty" jsonschema:"Bypass cache and fetch fresh content"`
+}
+
+type browseResult struct {
+	URL        string   `json:"url"`
+	Title      string   `json:"title"`
+	Content    string   `json:"content"`
+	HTML       string   `json:"html,omitempty"`
+	Links      []string `json:"links"`
+	StatusCode int      `json:"status_code"`
+}
+
+// NewBrowseTool creates an ADK tool that scrapes a URL via the Supacrawl API.
+// The agent sees the page as markdown + metadata, enabling DOM-level reasoning.
+func NewBrowseTool(client *supacrawl.Client) (tool.Tool, error) {
+	browseFn := func(tc tool.Context, args browseArgs) (browseResult, error) {
+		resp, err := client.Scrape(tc, args.URL, supacrawl.ScrapeOptions{
+			Format:      "markdown",
+			IncludeHTML: args.IncludeHTML,
+			Fresh:       args.Fresh,
+		})
+		if err != nil {
+			return browseResult{}, fmt.Errorf("browse %s: %w", args.URL, err)
+		}
+
+		links := resp.Links
+		if len(links) > 50 {
+			links = links[:50]
+		}
+
+		content := resp.Content
+		if len(content) > 8000 {
+			content = content[:8000] + "\n... [truncated]"
+		}
+
+		html := resp.HTML
+		if len(html) > 8000 {
+			html = html[:8000] + "\n... [truncated]"
+		}
+
+		return browseResult{
+			URL:        resp.URL,
+			Title:      resp.Title,
+			Content:    content,
+			HTML:       html,
+			Links:      links,
+			StatusCode: resp.Metadata.StatusCode,
+		}, nil
+	}
+
+	return functiontool.New(
+		functiontool.Config{
+			Name:        "browse",
+			Description: "Browse a web page and get its content as markdown. Returns the page title, markdown content, links, and HTTP status. Use this to read and analyze web pages.",
+		},
+		browseFn,
+	)
+}
+
+type screenshotArgs struct {
+	URL             string `json:"url" jsonschema:"The URL to take a screenshot of"`
+	FullPage        bool   `json:"full_page,omitempty" jsonschema:"Capture the full scrollable page instead of just the viewport"`
+	ClickSelector   string `json:"click_selector,omitempty" jsonschema:"CSS selector of an element to click before taking the screenshot"`
+	WaitForSelector string `json:"wait_for_selector,omitempty" jsonschema:"CSS selector to wait for before taking the screenshot"`
+}
+
+type screenshotResult struct {
+	URL           string `json:"url"`
+	ScreenshotURL string `json:"screenshot_url"`
+	Width         int    `json:"width"`
+	Height        int    `json:"height"`
+	Format        string `json:"format"`
+	LoadTime      int    `json:"load_time_ms"`
+}
+
+// NewScreenshotTool creates an ADK tool that takes screenshots via the Supacrawl API.
+// Returns the screenshot URL which can be fetched for multimodal analysis.
+func NewScreenshotTool(client *supacrawl.Client) (tool.Tool, error) {
+	screenshotFn := func(tc tool.Context, args screenshotArgs) (screenshotResult, error) {
+		resp, err := client.Screenshot(tc, supacrawl.ScreenshotRequest{
+			URL:             args.URL,
+			FullPage:        args.FullPage,
+			Format:          "png",
+			WaitUntil:       "networkidle",
+			ClickSelector:   args.ClickSelector,
+			WaitForSelector: args.WaitForSelector,
+			BlockAds:        true,
+		})
+		if err != nil {
+			return screenshotResult{}, fmt.Errorf("screenshot %s: %w", args.URL, err)
+		}
+
+		width, height, format := 0, 0, "png"
+		loadTime := 0
+		if resp.Metadata != nil {
+			width = resp.Metadata.Width
+			height = resp.Metadata.Height
+			if resp.Metadata.Format != "" {
+				format = resp.Metadata.Format
+			}
+			loadTime = resp.Metadata.LoadTime
+		}
+
+		return screenshotResult{
+			URL:           resp.URL,
+			ScreenshotURL: resp.Screenshot,
+			Width:         width,
+			Height:        height,
+			Format:        format,
+			LoadTime:      loadTime,
+		}, nil
+	}
+
+	return functiontool.New(
+		functiontool.Config{
+			Name:        "screenshot",
+			Description: "Take a screenshot of a web page. Returns a URL to the screenshot image. Use this to visually inspect pages, find hidden elements, verify UI state, or capture evidence of vulnerabilities.",
+		},
+		screenshotFn,
+	)
+}
+
+type clickArgs struct {
+	URL      string `json:"url" jsonschema:"The URL of the page to interact with"`
+	Selector string `json:"selector" jsonschema:"CSS selector of the element to click"`
+}
+
+type clickResult struct {
+	URL           string `json:"url"`
+	Clicked       string `json:"clicked_selector"`
+	ScreenshotURL string `json:"screenshot_url"`
+	Content       string `json:"content_after_click"`
+}
+
+// NewClickTool creates an ADK tool that clicks an element and returns the resulting state.
+// Combines click_selector with screenshot + scrape for a single "interact and observe" action.
+func NewClickTool(client *supacrawl.Client) (tool.Tool, error) {
+	clickFn := func(tc tool.Context, args clickArgs) (clickResult, error) {
+		screenshotResp, err := client.Screenshot(tc, supacrawl.ScreenshotRequest{
+			URL:           args.URL,
+			ClickSelector: args.Selector,
+			Format:        "png",
+			WaitUntil:     "networkidle",
+			BlockAds:      true,
+			Delay:         2,
+		})
+		if err != nil {
+			return clickResult{}, fmt.Errorf("click %s on %s: %w", args.Selector, args.URL, err)
+		}
+
+		scrapeResp, err := client.Scrape(tc, args.URL, supacrawl.ScrapeOptions{
+			Format: "markdown",
+			Fresh:  true,
+		})
+
+		content := ""
+		if err == nil && scrapeResp != nil {
+			content = scrapeResp.Content
+			if len(content) > 4000 {
+				content = content[:4000] + "\n... [truncated]"
+			}
+		}
+
+		return clickResult{
+			URL:           args.URL,
+			Clicked:       args.Selector,
+			ScreenshotURL: screenshotResp.Screenshot,
+			Content:       content,
+		}, nil
+	}
+
+	return functiontool.New(
+		functiontool.Config{
+			Name:        "click",
+			Description: "Click an element on a web page by CSS selector. Takes a screenshot after clicking and returns the new page state. Use this to interact with buttons, links, forms, and other clickable elements.",
+		},
+		clickFn,
+	)
+}
+
+// NewSupacrawlTools creates all Supacrawl-powered tools for the agent.
+func NewSupacrawlTools(client *supacrawl.Client) ([]tool.Tool, error) {
+	var tools []tool.Tool
+	var errs []string
+
+	browse, err := NewBrowseTool(client)
+	if err != nil {
+		errs = append(errs, fmt.Sprintf("browse: %v", err))
+	} else {
+		tools = append(tools, browse)
+	}
+
+	screenshot, err := NewScreenshotTool(client)
+	if err != nil {
+		errs = append(errs, fmt.Sprintf("screenshot: %v", err))
+	} else {
+		tools = append(tools, screenshot)
+	}
+
+	click, err := NewClickTool(client)
+	if err != nil {
+		errs = append(errs, fmt.Sprintf("click: %v", err))
+	} else {
+		tools = append(tools, click)
+	}
+
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("failed to create tools: %s", strings.Join(errs, "; "))
+	}
+
+	return tools, nil
 }

--- a/apps/golem/internal/adk/tools_test.go
+++ b/apps/golem/internal/adk/tools_test.go
@@ -2,6 +2,8 @@ package adk
 
 import (
 	"testing"
+
+	"golem/internal/supacrawl"
 )
 
 func TestNewEchoTool(t *testing.T) {
@@ -14,5 +16,59 @@ func TestNewEchoTool(t *testing.T) {
 	}
 	if tool.Description() != "Echoes back a message. Use this to test that tool calling works." {
 		t.Errorf("unexpected description: %q", tool.Description())
+	}
+}
+
+func TestNewBrowseTool(t *testing.T) {
+	client := supacrawl.NewClientWithURL("http://localhost:9999")
+	tool, err := NewBrowseTool(client)
+	if err != nil {
+		t.Fatalf("NewBrowseTool() error: %v", err)
+	}
+	if tool.Name() != "browse" {
+		t.Errorf("expected tool name 'browse', got %q", tool.Name())
+	}
+}
+
+func TestNewScreenshotTool(t *testing.T) {
+	client := supacrawl.NewClientWithURL("http://localhost:9999")
+	tool, err := NewScreenshotTool(client)
+	if err != nil {
+		t.Fatalf("NewScreenshotTool() error: %v", err)
+	}
+	if tool.Name() != "screenshot" {
+		t.Errorf("expected tool name 'screenshot', got %q", tool.Name())
+	}
+}
+
+func TestNewClickTool(t *testing.T) {
+	client := supacrawl.NewClientWithURL("http://localhost:9999")
+	tool, err := NewClickTool(client)
+	if err != nil {
+		t.Fatalf("NewClickTool() error: %v", err)
+	}
+	if tool.Name() != "click" {
+		t.Errorf("expected tool name 'click', got %q", tool.Name())
+	}
+}
+
+func TestNewSupacrawlTools(t *testing.T) {
+	client := supacrawl.NewClientWithURL("http://localhost:9999")
+	tools, err := NewSupacrawlTools(client)
+	if err != nil {
+		t.Fatalf("NewSupacrawlTools() error: %v", err)
+	}
+	if len(tools) != 3 {
+		t.Errorf("expected 3 tools, got %d", len(tools))
+	}
+
+	names := make(map[string]bool)
+	for _, tool := range tools {
+		names[tool.Name()] = true
+	}
+	for _, expected := range []string{"browse", "screenshot", "click"} {
+		if !names[expected] {
+			t.Errorf("missing tool %q", expected)
+		}
 	}
 }

--- a/apps/golem/internal/supacrawl/client.go
+++ b/apps/golem/internal/supacrawl/client.go
@@ -1,0 +1,287 @@
+package supacrawl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+func NewClient() (*Client, error) {
+	base := os.Getenv("SUPACRAWL_API_URL")
+	if base == "" {
+		return nil, fmt.Errorf("SUPACRAWL_API_URL is required")
+	}
+	base = strings.TrimRight(base, "/")
+
+	return &Client{
+		baseURL: base,
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+	}, nil
+}
+
+func NewClientWithURL(baseURL string) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+	}
+}
+
+// ScrapeResponse represents the scraper API response for /v1/scrape.
+type ScrapeResponse struct {
+	Success    bool           `json:"success"`
+	URL        string         `json:"url"`
+	Title      string         `json:"title"`
+	Content    string         `json:"content"`
+	HTML       string         `json:"html,omitempty"`
+	Links      []string       `json:"links"`
+	Discovered int            `json:"discovered"`
+	Metadata   ScrapeMetadata `json:"metadata"`
+	Error      string         `json:"error,omitempty"`
+}
+
+type ScrapeMetadata struct {
+	StatusCode    int    `json:"status_code"`
+	Title         string `json:"title"`
+	Description   string `json:"description"`
+	Language      string `json:"language"`
+	OgTitle       string `json:"og_title"`
+	OgDescription string `json:"og_description"`
+	OgImage       string `json:"og_image"`
+}
+
+type ScrapeOptions struct {
+	Format      string // markdown, links
+	IncludeHTML bool
+	Fresh       bool
+}
+
+// Scrape fetches and returns the markdown content + metadata for a URL.
+func (c *Client) Scrape(ctx context.Context, targetURL string, opts ScrapeOptions) (*ScrapeResponse, error) {
+	params := url.Values{}
+	params.Set("url", targetURL)
+	if opts.Format != "" {
+		params.Set("format", opts.Format)
+	}
+	if opts.IncludeHTML {
+		params.Set("include_html", "true")
+	}
+	if opts.Fresh {
+		params.Set("fresh", "true")
+	}
+
+	endpoint := fmt.Sprintf("%s/v1/scrape?%s", c.baseURL, params.Encode())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build scrape request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("scrape request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read scrape response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("scrape returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result ScrapeResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decode scrape response: %w", err)
+	}
+
+	if !result.Success {
+		return nil, fmt.Errorf("scrape failed: %s", result.Error)
+	}
+
+	return &result, nil
+}
+
+// ScreenshotRequest represents the POST body for /v1/screenshots.
+type ScreenshotRequest struct {
+	URL             string `json:"url"`
+	FullPage        bool   `json:"full_page,omitempty"`
+	Format          string `json:"format,omitempty"`
+	Width           int    `json:"width,omitempty"`
+	Height          int    `json:"height,omitempty"`
+	WaitUntil       string `json:"wait_until,omitempty"`
+	WaitForSelector string `json:"wait_for_selector,omitempty"`
+	ClickSelector   string `json:"click_selector,omitempty"`
+	BlockAds        bool   `json:"block_ads,omitempty"`
+	DarkMode        bool   `json:"dark_mode,omitempty"`
+	Delay           int    `json:"delay,omitempty"`
+}
+
+type ScreenshotJobResponse struct {
+	Success  bool                `json:"success"`
+	JobID    string              `json:"job_id"`
+	Status   string              `json:"status"`
+	URL      string              `json:"url"`
+	Metadata *ScreenshotMetadata `json:"metadata,omitempty"`
+	Error    string              `json:"error,omitempty"`
+}
+
+type ScreenshotGetResponse struct {
+	Success    bool                `json:"success"`
+	JobID      string              `json:"job_id"`
+	URL        string              `json:"url"`
+	Screenshot string              `json:"screenshot"`
+	Status     string              `json:"status"`
+	Metadata   *ScreenshotMetadata `json:"metadata,omitempty"`
+	Error      string              `json:"error,omitempty"`
+}
+
+type ScreenshotMetadata struct {
+	Width       int     `json:"width"`
+	Height      int     `json:"height"`
+	Format      string  `json:"format"`
+	FileSize    int     `json:"file_size"`
+	LoadTime    int     `json:"load_time"`
+	Device      string  `json:"device"`
+	DeviceScale float64 `json:"device_scale"`
+}
+
+// Screenshot creates a screenshot job and polls until complete.
+func (c *Client) Screenshot(ctx context.Context, req ScreenshotRequest) (*ScreenshotGetResponse, error) {
+	jobResp, err := c.createScreenshot(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.pollScreenshot(ctx, jobResp.JobID)
+}
+
+func (c *Client) createScreenshot(ctx context.Context, req ScreenshotRequest) (*ScreenshotJobResponse, error) {
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal screenshot request: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("%s/v1/screenshots", c.baseURL)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(string(payload)))
+	if err != nil {
+		return nil, fmt.Errorf("build screenshot request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("screenshot request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read screenshot response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("screenshot returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result ScreenshotJobResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decode screenshot response: %w", err)
+	}
+
+	if !result.Success {
+		return nil, fmt.Errorf("screenshot job creation failed: %s", result.Error)
+	}
+
+	return &result, nil
+}
+
+func (c *Client) pollScreenshot(ctx context.Context, jobID string) (*ScreenshotGetResponse, error) {
+	params := url.Values{}
+	params.Set("job_id", jobID)
+	endpoint := fmt.Sprintf("%s/v1/screenshots?%s", c.baseURL, params.Encode())
+
+	maxAttempts := 30
+	for i := 0; i < maxAttempts; i++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return nil, fmt.Errorf("build screenshot poll request: %w", err)
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("screenshot poll failed: %w", err)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("read screenshot poll response: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("screenshot poll returned %d: %s", resp.StatusCode, string(body))
+		}
+
+		var result ScreenshotGetResponse
+		if err := json.Unmarshal(body, &result); err != nil {
+			return nil, fmt.Errorf("decode screenshot poll response: %w", err)
+		}
+
+		switch result.Status {
+		case "completed":
+			return &result, nil
+		case "failed":
+			return nil, fmt.Errorf("screenshot job failed: %s", result.Error)
+		case "processing":
+			time.Sleep(time.Second)
+			continue
+		default:
+			return nil, fmt.Errorf("unexpected screenshot status: %s", result.Status)
+		}
+	}
+
+	return nil, fmt.Errorf("screenshot job %s timed out after %d attempts", jobID, maxAttempts)
+}
+
+// Health checks the scraper service health.
+func (c *Client) Health(ctx context.Context) error {
+	endpoint := fmt.Sprintf("%s/v1/health", c.baseURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("build health request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("health check failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("health check returned %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/apps/golem/internal/supacrawl/client_test.go
+++ b/apps/golem/internal/supacrawl/client_test.go
@@ -1,0 +1,265 @@
+package supacrawl
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewClient_MissingEnv(t *testing.T) {
+	t.Setenv("SUPACRAWL_API_URL", "")
+	_, err := NewClient()
+	if err == nil {
+		t.Fatal("expected error for missing SUPACRAWL_API_URL")
+	}
+}
+
+func TestNewClient_WithEnv(t *testing.T) {
+	t.Setenv("SUPACRAWL_API_URL", "http://localhost:8082")
+	c, err := NewClient()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.baseURL != "http://localhost:8082" {
+		t.Errorf("expected baseURL http://localhost:8082, got %s", c.baseURL)
+	}
+}
+
+func TestNewClientWithURL(t *testing.T) {
+	c := NewClientWithURL("http://example.com/")
+	if c.baseURL != "http://example.com" {
+		t.Errorf("expected trailing slash stripped, got %s", c.baseURL)
+	}
+}
+
+func TestHealth_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/health" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithURL(srv.URL)
+	if err := c.Health(context.Background()); err != nil {
+		t.Fatalf("health check failed: %v", err)
+	}
+}
+
+func TestHealth_Failure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c := NewClientWithURL(srv.URL)
+	if err := c.Health(context.Background()); err == nil {
+		t.Fatal("expected error for unhealthy service")
+	}
+}
+
+func TestScrape_Success(t *testing.T) {
+	expected := ScrapeResponse{
+		Success: true,
+		URL:     "https://example.com",
+		Title:   "Example",
+		Content: "# Hello World",
+		Links:   []string{"https://example.com/about"},
+		Metadata: ScrapeMetadata{
+			StatusCode: 200,
+			Title:      "Example",
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/scrape" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("url") != "https://example.com" {
+			t.Errorf("unexpected url param: %s", r.URL.Query().Get("url"))
+		}
+		if r.URL.Query().Get("format") != "markdown" {
+			t.Errorf("unexpected format param: %s", r.URL.Query().Get("format"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(expected)
+	}))
+	defer srv.Close()
+
+	c := NewClientWithURL(srv.URL)
+	resp, err := c.Scrape(context.Background(), "https://example.com", ScrapeOptions{
+		Format: "markdown",
+	})
+	if err != nil {
+		t.Fatalf("scrape failed: %v", err)
+	}
+	if resp.Title != "Example" {
+		t.Errorf("expected title Example, got %s", resp.Title)
+	}
+	if resp.Content != "# Hello World" {
+		t.Errorf("expected content '# Hello World', got %s", resp.Content)
+	}
+	if resp.Metadata.StatusCode != 200 {
+		t.Errorf("expected status 200, got %d", resp.Metadata.StatusCode)
+	}
+}
+
+func TestScrape_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"success":false,"error":"invalid url"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithURL(srv.URL)
+	_, err := c.Scrape(context.Background(), "bad-url", ScrapeOptions{})
+	if err == nil {
+		t.Fatal("expected error for bad request")
+	}
+}
+
+func TestScrape_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(ScrapeResponse{
+			Success: false,
+			Error:   "page not found",
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClientWithURL(srv.URL)
+	_, err := c.Scrape(context.Background(), "https://example.com/404", ScrapeOptions{})
+	if err == nil {
+		t.Fatal("expected error for API failure")
+	}
+}
+
+func TestScrape_WithOptions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("include_html") != "true" {
+			t.Error("expected include_html=true")
+		}
+		if q.Get("fresh") != "true" {
+			t.Error("expected fresh=true")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(ScrapeResponse{
+			Success: true,
+			URL:     "https://example.com",
+			HTML:    "<h1>Hello</h1>",
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClientWithURL(srv.URL)
+	resp, err := c.Scrape(context.Background(), "https://example.com", ScrapeOptions{
+		IncludeHTML: true,
+		Fresh:       true,
+	})
+	if err != nil {
+		t.Fatalf("scrape failed: %v", err)
+	}
+	if resp.HTML != "<h1>Hello</h1>" {
+		t.Errorf("expected HTML content, got %s", resp.HTML)
+	}
+}
+
+func TestCreateScreenshot_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/v1/screenshots" {
+			var req ScreenshotRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.URL != "https://example.com" {
+				t.Errorf("expected url https://example.com, got %s", req.URL)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(ScreenshotJobResponse{
+				Success: true,
+				JobID:   "job-123",
+				Status:  "processing",
+			})
+			return
+		}
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/screenshots" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(ScreenshotGetResponse{
+				Success:    true,
+				JobID:      "job-123",
+				Screenshot: "https://cdn.example.com/screenshot.png",
+				Status:     "completed",
+				Metadata: &ScreenshotMetadata{
+					Width:  1280,
+					Height: 720,
+					Format: "png",
+				},
+			})
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	c := NewClientWithURL(srv.URL)
+	resp, err := c.Screenshot(context.Background(), ScreenshotRequest{
+		URL: "https://example.com",
+	})
+	if err != nil {
+		t.Fatalf("screenshot failed: %v", err)
+	}
+	if resp.Screenshot != "https://cdn.example.com/screenshot.png" {
+		t.Errorf("expected screenshot URL, got %s", resp.Screenshot)
+	}
+	if resp.Metadata.Width != 1280 {
+		t.Errorf("expected width 1280, got %d", resp.Metadata.Width)
+	}
+}
+
+func TestCreateScreenshot_Failed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(ScreenshotJobResponse{
+				Success: true,
+				JobID:   "job-fail",
+				Status:  "processing",
+			})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(ScreenshotGetResponse{
+			Success: false,
+			Status:  "failed",
+			Error:   "timeout loading page",
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClientWithURL(srv.URL)
+	_, err := c.Screenshot(context.Background(), ScreenshotRequest{
+		URL: "https://slow-site.example.com",
+	})
+	if err == nil {
+		t.Fatal("expected error for failed screenshot")
+	}
+}
+
+func TestCreateScreenshot_PostFailed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]any{"success": false, "error": "missing url"})
+	}))
+	defer srv.Close()
+
+	c := NewClientWithURL(srv.URL)
+	_, err := c.Screenshot(context.Background(), ScreenshotRequest{})
+	if err == nil {
+		t.Fatal("expected error for bad request")
+	}
+}


### PR DESCRIPTION
## Summary

- Implement the Supacrawl Go HTTP client (`internal/supacrawl/`) with scrape, screenshot (async job + polling), and health check methods
- Add three ADK tools via `functiontool.New` closures that give the agent its perception capabilities:
  - `browse`: scrapes a URL, returns markdown content + links + metadata
  - `screenshot`: takes a screenshot, returns image URL for visual reasoning
  - `click`: clicks a CSS selector, then screenshots + scrapes the result
- Graceful degradation: if `SUPACRAWL_API_URL` is unset or scraper is unreachable, agent starts with `echo` tool only
- Address PR #17 Gemini review: runner error wrapping, `.env.example` alignment (already on main)
- Tools use `tool.Context` (which embeds `context.Context`) for proper cancellation propagation

## Related Issues

Closes #4 (v0.2.1: Supacrawl Go client)
Closes #5 (v0.2.2: browse tool)
Closes #6 (v0.2.3: screenshot tool)

## Architecture

```
internal/supacrawl/
  client.go          -> HTTP client (Scrape, Screenshot, Health)
  client_test.go     -> 12 httptest-based tests

internal/adk/
  tools.go           -> echo + browse + screenshot + click tool definitions
  tools_test.go      -> tool registration tests (5 tests)

cmd/golem/main.go    -> buildTools() wiring with graceful degradation
```

### Tool Data Flow

```
Agent decides to browse -> browse tool -> supacrawl.Scrape() -> GET /v1/scrape -> markdown + links
Agent decides to screenshot -> screenshot tool -> supacrawl.Screenshot() -> POST /v1/screenshots + poll -> image URL
Agent decides to click -> click tool -> supacrawl.Screenshot(click_selector) + Scrape(fresh) -> screenshot + new content
```

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (22 tests: 12 client + 10 adk)
- [x] Pre-commit hooks pass (gofmt, govet, gotest, shellcheck, yaml)
- [x] AI code review saved to `tmp/reviews/feat-4-supacrawl-client-review.md`

## Review findings addressed

| Finding | Resolution |
|---------|-----------|
| Health endpoint was `/internal/health` | Fixed to `/v1/health` (matches scraper routes.go) |
| Tools used `context.Background()` | Changed to use `tc` (tool.Context embeds context.Context) |
| Runner error not wrapped | Added `fmt.Errorf("create runner: %w", err)` |
| `.env.example` stale vars | Already fixed on main in PR #17 follow-up |

## Next

v0.4.1: Security system prompt refinement (critical path)