### PR TITLE
fix(observer): handle nullable onValueChange in ModelSelector

### DIFF
--- a/apps/observer/src/components/model-selector.tsx
+++ b/apps/observer/src/components/model-selector.tsx
@@ -44,7 +44,7 @@ export function ModelSelector({ model, onSelect, disabled }: ModelSelectorProps)
   const label = selected?.label ?? model;
 
   return (
-    <Select value={model} onValueChange={onSelect} disabled={disabled}>
+    <Select value={model} onValueChange={(val) => { if (val) onSelect(val); }} disabled={disabled}>
       <SelectTrigger size="sm" className="text-xs h-7 gap-1 min-w-[120px]" title="Select Gemini model for agent runs">
         <SelectValue>{label}</SelectValue>
       </SelectTrigger>


### PR DESCRIPTION
## Summary

- Fixes observer Docker build failure caused by TS2322 type mismatch in `model-selector.tsx`
- base-ui `Select.Root`'s `onValueChange` callback signature is `(value: string | null, eventDetails) => void`, but `onSelect` was typed as `(model: string) => void`
- Wraps the callback to guard against `null` values before forwarding to `onSelect`

Closes the build failure from [run #23171061446](https://github.com/antoineross/golem/actions/runs/23171061446/job/67322812216).

## Test plan

- [x] `npx tsc --noEmit` passes locally
- [x] `docker build --target build` passes (full `tsc -b && vite build` in Docker)
- [x] pre-commit hooks pass
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes